### PR TITLE
JRuby String#bytes returns enum

### DIFF
--- a/lib/base32.rb
+++ b/lib/base32.rb
@@ -62,6 +62,6 @@ module Base32
   end
 
   def self.table_valid?(table)
-    table.bytes.size == 32 && table.bytes.uniq.size == 32
+    table.bytes.to_a.size == 32 && table.bytes.to_a.uniq.size == 32
   end
 end


### PR DESCRIPTION
Calling `table.bytes.size` is failing in JRuby because of an
[incompatability between JRuby and MRI](https://github.com/jruby/jruby/issues/1109).

In MRI 1.8 and 1.9 `String#bytes` returned an Enumerator. MRI 2.x changes this
behavior to return an array. JRuby <= 1.7.x mimics the 1.9 behavior of
returning an Enumerator.

The simple solution is to call to_a on the returned bytes when we are checking
the byte size of the newly assigned table.

I've run the tests in MRI 2.0.0-p195 and JRuby 1.7.8 with this change and all appears
to be working.
