### PR TITLE
make padding optional for random_base32

### DIFF
--- a/lib/base32.rb
+++ b/lib/base32.rb
@@ -44,12 +44,12 @@ module Base32
     chunks(str, 8).collect(&:decode).flatten.join
   end
 
-  def self.random_base32(length=16)
+  def self.random_base32(length=16, padding=true)
     random = ''
     OpenSSL::Random.random_bytes(length).each_byte do |b|
       random << self.table[b % 32]
     end
-    random.ljust((length / 8.0).ceil * 8, '=') # add padding
+    padding ? random.ljust((length / 8.0).ceil * 8, '=') : random
   end
 
   def self.table=(table)

--- a/test/base32_test.rb
+++ b/test/base32_test.rb
@@ -84,6 +84,14 @@ class TestBase32 < Minitest::Test
     assert_match(/^[A-Z2-7]{29}={3}$/, Base32.random_base32(29))
   end
 
+  def test_random_base32_padding
+    assert_equal(32, Base32.random_base32(32, false).length)
+    assert_equal(40, Base32.random_base32(40, false).length)
+    assert_equal(29, Base32.random_base32(29, false).length)
+    assert_match(/^[A-Z2-7]{1}$/, Base32.random_base32(1, false))
+    assert_match(/^[A-Z2-7]{29}$/, Base32.random_base32(29, false))
+  end
+
   def test_assign_new_table
     new_table =  'abcdefghijklmnopqrstuvwxyz234567'
     Base32.table = new_table


### PR DESCRIPTION
When you're just generating random values, you don't always want them to be padded. Thought this might be a worthwhile option to add. Thanks! 
