### PR TITLE
fix build errors

### DIFF
--- a/base32.gemspec
+++ b/base32.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.has_rdoc = true
-  s.extra_rdoc_files = ['README']
+  s.extra_rdoc_files = ['README.md']
 
   s.post_install_message = File.read('UPGRADING') if File.exists?('UPGRADING')
 


### PR DESCRIPTION
Hi, I got following errors when packaging this gem.

```
$ rake build
rake aborted!
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["README"] are not files

Tasks: TOP => build
(See full trace by running task with --trace)
```