### PR TITLE
Add Ruby version 3.0, 3.1, 3.2 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
+  - 3.0
+  - 3.1
+  - 3.2
   - ruby-head
   - rbx-19mode
   - truffleruby-head


### PR DESCRIPTION
Since this gems works in Ruby 3.0, 3.1, and 3.2 we could add it to travis to run tests on regular basis.

See also https://gitlab.com/gitlab-org/gitlab/-/issues/422665#note_1555206155.